### PR TITLE
Potential fix for code scanning alert no. 24: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -295,6 +295,8 @@ jobs:
     needs: [backend-deploy]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      contents: read
     
     steps:
     - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/sistar/location-tracker/security/code-scanning/24](https://github.com/sistar/location-tracker/security/code-scanning/24)

To fix the issue, we will add a `permissions` block to the `performance-test` job. Since the job does not appear to require write access to any resources, we will set the permissions to `contents: read`, which is the minimal required permission for most jobs. This ensures that the `GITHUB_TOKEN` has only the access it needs.

The changes will be made in the `.github/workflows/ci-cd.yml` file, specifically within the `performance-test` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
